### PR TITLE
Add quotes to DEBUG env value

### DIFF
--- a/charts/komoplane/templates/deployment.yaml
+++ b/charts/komoplane/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: DEBUG
-              value: {{- ternary " 1" "" .Values.komoplane.debug }}
+              value: {{- ternary " '1'" "" .Values.komoplane.debug }}
           ports:
             - name: http
               containerPort: 8090


### PR DESCRIPTION
Add quotes to the value for DEBUG so that the `1` gets handled as a string and not a number.

Fixes #17 