### PR TITLE
feat(helm-chart): add annotations and labels to resources

### DIFF
--- a/charts/komoplane/templates/ingress.yaml
+++ b/charts/komoplane/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
+  {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/komoplane/templates/service.yaml
+++ b/charts/komoplane/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "app.fullname" . }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/komoplane/templates/service.yaml
+++ b/charts/komoplane/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "app.fullname" . }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
+  {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/komoplane/templates/serviceaccount.yaml
+++ b/charts/komoplane/templates/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "app.serviceAccountName" . }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/komoplane/templates/serviceaccount.yaml
+++ b/charts/komoplane/templates/serviceaccount.yaml
@@ -15,6 +15,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "app.serviceAccountName" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
@@ -24,6 +26,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "app.serviceAccountName" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/komoplane/values.yaml
+++ b/charts/komoplane/values.yaml
@@ -22,6 +22,7 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  annotations: { }
   labels: { }
 
 resources:

--- a/charts/komoplane/values.yaml
+++ b/charts/komoplane/values.yaml
@@ -22,6 +22,7 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  labels: { }
 
 resources:
   requests:
@@ -64,11 +65,13 @@ service:
   type: ClusterIP
   port: 8090
   annotations: { }
+  labels: { }
 
 ingress:
   enabled: false
   className: ""
   annotations: { }
+  labels: { }
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/komoplane/values.yaml
+++ b/charts/komoplane/values.yaml
@@ -63,6 +63,7 @@ securityContext:
 service:
   type: ClusterIP
   port: 8090
+  annotations: { }
 
 ingress:
   enabled: false


### PR DESCRIPTION
Fixes https://github.com/komodorio/komoplane/issues/52.

---

- feat: add default labels to ClusterRole and ClusterRoleBinding
- feat: add ability to specify annotations for service
- feat: add ability to specify labels for Ingress, Service & ServiceAccount
- fix: add missing serviceAccount.annotations to values.yaml
