### PR TITLE
Fix list filtering for multiple types with same name

### DIFF
--- a/pkg/frontend/src/components/CompositeResourcesList.tsx
+++ b/pkg/frontend/src/components/CompositeResourcesList.tsx
@@ -62,7 +62,7 @@ export default function CompositeResourcesList({items}: ItemListProps) {
         );
     }
 
-    let fApiVersion = fGroup + "/" + fVersion;
+    const fApiVersion = fGroup + "/" + fVersion;
 
     if (fName && focused.metadata.name != fName) {
         items?.items?.forEach((item) => {

--- a/pkg/frontend/src/components/ManagedResourcesList.tsx
+++ b/pkg/frontend/src/components/ManagedResourcesList.tsx
@@ -60,7 +60,7 @@ export default function ManagedResourcesList({items}: ItemListProps) {
         );
     }
 
-    let fApiVersion = fGroup + "/" + fVersion;
+    const fApiVersion = fGroup + "/" + fVersion;
 
     if (!focused.metadata.name && fName) {
         items?.items?.forEach((item) => {


### PR DESCRIPTION
List filtering for CompositeResourcesList and ManagedResourcesList fail when there's multiple resources with the same name but with different types. this is caused by a naive lookup that only compares on focusedName

```
if (focusedName == item.metadata.name)
```

The implemented solution is to compare against group, version and kind (which are defined in the routes for these lists)

The problem is explained further here: https://github.com/komodorio/komoplane/issues/78

Tested locally.

Fixes #78