### PR TITLE
fix: support namespaced composite resources in Crossplane v2

### DIFF
--- a/pkg/backend/controller.go
+++ b/pkg/backend/controller.go
@@ -568,8 +568,12 @@ func (c *Controller) GetComposite(ec echo.Context) error {
 	ref := v12.ObjectReference{Name: ec.Param("name")}
 	ref.SetGroupVersionKind(gvk)
 
+	return c.getCompositeInner(ec, &ref)
+}
+
+func (c *Controller) getCompositeInner(ec echo.Context, ref *v12.ObjectReference) error {
 	xr := uxres.New()
-	err := c.getDynamicResource(&ref, xr)
+	err := c.getDynamicResource(ref, xr)
 	if err != nil {
 		return err
 	}
@@ -692,14 +696,7 @@ func (c *Controller) GetCompositeNamespaced(ec echo.Context) error {
 	}
 	ref.SetGroupVersionKind(gvk)
 
-	xr := uxres.New()
-	err := c.getDynamicResource(&ref, xr)
-	if err != nil {
-		return err
-	}
-
-	c.fillCompositionByRef(xr)
-	return ec.JSONPretty(http.StatusOK, xr, "  ")
+	return c.getCompositeInner(ec, &ref)
 }
 
 func (c *Controller) fillManagedResources(ec echo.Context, xr *uxres.Unstructured) error {

--- a/pkg/backend/crossplane/crds_test.go
+++ b/pkg/backend/crossplane/crds_test.go
@@ -7,11 +7,27 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	xpv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 )
+
+type mockXRDClient struct {
+	items []xpv1.CompositeResourceDefinition
+}
+
+func (m *mockXRDClient) List(_ context.Context) (*xpv1.CompositeResourceDefinitionList, error) {
+	return &xpv1.CompositeResourceDefinitionList{Items: m.items}, nil
+}
+
+func (m *mockXRDClient) Get(_ context.Context, _ string) (*xpv1.CompositeResourceDefinition, error) {
+	return nil, nil
+}
 
 func TestCRDClient_List_AllNamespaces(t *testing.T) {
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -51,6 +67,73 @@ func TestCRDClient_List_AllNamespaces(t *testing.T) {
 	result, err := client.List(context.Background(), gvk)
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 3)
+}
+
+func TestCRDClient_Get_Namespaced(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "namespaces/default", "should target the specific namespace")
+		assert.Contains(t, r.URL.Path, "xapps/reference-data")
+
+		response := map[string]interface{}{
+			"apiVersion": "vpi.test.io/v1",
+			"kind":       "XApp",
+			"metadata":   map[string]interface{}{"name": "reference-data", "namespace": "default"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer testServer.Close()
+
+	xrds := &mockXRDClient{items: []xpv1.CompositeResourceDefinition{
+		{Spec: xpv1.CompositeResourceDefinitionSpec{
+			Group: "vpi.test.io",
+			Names: extv1.CustomResourceDefinitionNames{Kind: "XApp", Plural: "xapps"},
+		}},
+	}}
+	client := &crdClient{cfg: &rest.Config{Host: testServer.URL}, XRDs: xrds}
+
+	ref := &v1.ObjectReference{Name: "reference-data", Namespace: "default"}
+	ref.SetGroupVersionKind(schema.FromAPIVersionAndKind("vpi.test.io/v1", "XApp"))
+
+	result := &unstructured.Unstructured{}
+	err := client.Get(context.Background(), result, ref)
+	require.NoError(t, err)
+	assert.Equal(t, "reference-data", result.GetName())
+	assert.Equal(t, "default", result.GetNamespace())
+}
+
+func TestCRDClient_Get_ClusterScoped(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.NotContains(t, r.URL.Path, "namespaces/", "should not target a specific namespace")
+		assert.Contains(t, r.URL.Path, "xkomodorchartsets/my-test-set1")
+
+		response := map[string]interface{}{
+			"apiVersion": "xrd.komodor.com/v1alpha1",
+			"kind":       "XKomodorChartSet",
+			"metadata":   map[string]interface{}{"name": "my-test-set1"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer testServer.Close()
+
+	xrds := &mockXRDClient{items: []xpv1.CompositeResourceDefinition{
+		{Spec: xpv1.CompositeResourceDefinitionSpec{
+			Group: "xrd.komodor.com",
+			Names: extv1.CustomResourceDefinitionNames{Kind: "XKomodorChartSet", Plural: "xkomodorchartsets"},
+		}},
+	}}
+	client := &crdClient{cfg: &rest.Config{Host: testServer.URL}, XRDs: xrds}
+
+	ref := &v1.ObjectReference{Name: "my-test-set1"}
+	ref.SetGroupVersionKind(schema.FromAPIVersionAndKind("xrd.komodor.com/v1alpha1", "XKomodorChartSet"))
+
+	result := &unstructured.Unstructured{}
+	err := client.Get(context.Background(), result, ref)
+	require.NoError(t, err)
+	assert.Equal(t, "my-test-set1", result.GetName())
 }
 
 func TestCRDClient_List_ErrorHandling(t *testing.T) {

--- a/pkg/frontend/src/api.ts
+++ b/pkg/frontend/src/api.ts
@@ -94,8 +94,14 @@ class APIClient {
         return data;
     };
 
-    getCompositeResource = async (group?: string, version?: string, kind?: string, name?: string) => {
-        const response = await this.innterFetch(`/api/composite/` + group + "/" + version + "/" + kind + "/" + name + "?full=1");
+    getCompositeResource = async (group?: string, version?: string, kind?: string, name?: string, namespace?: string) => {
+        let url: string;
+        if (namespace) {
+            url = `/api/composite/${group}/${version}/${kind}/${namespace}/${name}?full=1`;
+        } else {
+            url = `/api/composite/${group}/${version}/${kind}/${name}?full=1`;
+        }
+        const response = await this.innterFetch(url);
         const data: CompositeResourceExtended = await response.json();
         return data;
     };

--- a/pkg/frontend/src/components/CompositeResourcesList.tsx
+++ b/pkg/frontend/src/components/CompositeResourcesList.tsx
@@ -27,6 +27,9 @@ function ListItem({item, onItemClick}: ItemProps) {
                     <Typography variant="h6">{item.metadata.name}</Typography>
                     <Typography variant="body1">Kind: {item.kind}</Typography>
                     <Typography variant="body1">Group: {item.apiVersion}</Typography>
+                    {item.metadata.namespace && (
+                        <Typography variant="body1">Namespace: {item.metadata.namespace}</Typography>
+                    )}
                     <Typography variant="body1">Composition: {item.spec.compositionRef?.name}</Typography>
                     <Typography variant="body1">Composed resources: {item.spec.resourceRefs?.length}</Typography>
                     <ReadySynced status={item.status ? item.status : {}}></ReadySynced>
@@ -41,7 +44,7 @@ type ItemListProps = {
 };
 
 export default function CompositeResourcesList({items}: ItemListProps) {
-    const {group: fGroup, version: fVersion, kind: fKind, name: fName} = useParams();
+    const {group: fGroup, version: fVersion, kind: fKind, namespace: fNamespace, name: fName} = useParams();
     const [isDrawerOpen, setDrawerOpen] = useState<boolean>(fName != undefined);
     const nullFocused = {metadata: {name: ""}, kind: "", apiVersion: ""};
     const [focused, setFocused] = useState<K8sResource>(nullFocused);
@@ -57,16 +60,23 @@ export default function CompositeResourcesList({items}: ItemListProps) {
     const onItemClick = (item: K8sResource) => {
         setFocused(item)
         setDrawerOpen(true)
-        navigate(
-            "./" + item.apiVersion + "/" + item.kind + "/" + item.metadata.name
-        );
+        if (item.metadata?.namespace) {
+            navigate(
+                "./" + item.apiVersion + "/" + item.kind + "/" + item.metadata.namespace + "/" + item.metadata.name
+            );
+        } else {
+            navigate(
+                "./" + item.apiVersion + "/" + item.kind + "/" + item.metadata.name
+            );
+        }
     }
 
     const fApiVersion = fGroup + "/" + fVersion;
 
     if (fName && focused.metadata.name != fName) {
         items?.items?.forEach((item) => {
-            if (item.metadata.name == fName && item.apiVersion == fApiVersion && item.kind == fKind) {
+            const namespaceMatches = fNamespace ? item.metadata?.namespace == fNamespace : !item.metadata?.namespace;
+            if (item.metadata.name == fName && item.apiVersion == fApiVersion && item.kind == fKind && namespaceMatches) {
                 logger.log("== SET FOCUSED", item)
                 setFocused(item)
             }
@@ -85,7 +95,7 @@ export default function CompositeResourcesList({items}: ItemListProps) {
             }
 
             const [group, version] = focused.apiVersion.split("/")
-            apiClient.getCompositeResource(group, version, focused.kind, focused.metadata.name)
+            apiClient.getCompositeResource(group, version, focused.kind, focused.metadata.name, focused.metadata?.namespace)
                 .then((data) => setData(data))
                 .catch((err) => setError(err))
         }

--- a/pkg/frontend/src/components/graph/data.ts
+++ b/pkg/frontend/src/components/graph/data.ts
@@ -127,7 +127,11 @@ export class GraphData {
                 url = "/compositions/" + res.metadata.name
                 break;
             case NodeTypes.CompositeResource:
-                url = "/composite/" + res.apiVersion + "/" + res.kind + "/" + res.metadata.name
+                if (res.metadata.namespace) {
+                    url = "/composite/" + res.apiVersion + "/" + res.kind + "/" + res.metadata.namespace + "/" + res.metadata.name
+                } else {
+                    url = "/composite/" + res.apiVersion + "/" + res.kind + "/" + res.metadata.name
+                }
                 break;
             case NodeTypes.ManagedResource:
                 if (res.metadata.namespace) {


### PR DESCRIPTION
## Summary

Fixes HTTP 500 when viewing namespaced composite resource (XR) details. Reported in #82.

In Crossplane v2, XRDs without `claimNames` create **namespaced** CRDs (not cluster-scoped). Two issues caused the 500:
- Backend: `GetCompositeNamespaced` handler lacked `?full=1` support (composition, claims, parent XR, managed resources)
- Frontend: always used cluster-scoped URLs when navigating to XR details

### Changes
- **controller.go**: Extract shared `getCompositeInner` helper, used by both `GetComposite` (cluster-scoped) and `GetCompositeNamespaced`
- **api.ts**: Add optional `namespace` param to `getCompositeResource`
- **CompositeResourcesList.tsx**: Namespace-aware navigation, URL matching, and API calls; show namespace in card when present
- **graph/data.ts**: Namespace-aware URL generation for composite resource graph nodes
- **crds_test.go**: Unit tests for namespaced vs cluster-scoped Get operations

Backwards compatible with Crossplane v1 (XRs always cluster-scoped).

## Test plan
- [x] Unit tests pass for namespaced and cluster-scoped Get
- [x] Manual test: namespaced XR (Crossplane v2 XRD) returns 200 with full details
- [x] Manual test: cluster-scoped XR (Crossplane v1 XRD) still returns 200
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)